### PR TITLE
Add block reconciler for incremental sync

### DIFF
--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -3,15 +3,12 @@ import {
   getPageUidByPageTitle,
   getPageTitlesStartingWithPrefix,
   createPage,
-  createBlock,
-  updateBlock,
   deleteBlock,
   delay,
   yieldToMain,
   maybeYield,
   MUTATION_DELAY_MS,
   type RoamBasicNode,
-  type InputTextNode,
 } from "./settings";
 
 import {
@@ -24,6 +21,13 @@ import {
   TODOIST_ID_PROPERTY,
   TODOIST_STATUS_PROPERTY,
 } from "./constants";
+
+import {
+  BlockReconciler,
+  createRoamApiAdapter,
+  type BlockPayload as ReconcilerBlockPayload,
+  type RoamNode,
+} from "./reconciler";
 import {
   formatDue,
   formatLabelTag,
@@ -233,66 +237,70 @@ function enrichTaskWithExistingDue(
   return task;
 }
 
+/**
+ * Creates a BlockReconciler configured for Todoist tasks.
+ */
+function createTodoistReconciler() {
+  const roamApi = createRoamApiAdapter();
+
+  return new BlockReconciler<BlockPayload>({
+    extractId: (block) => extractTodoistIdFromBlock(block) ?? "",
+    buildBlock: (block) => block as ReconcilerBlockPayload,
+    extractIdFromBlock: (node: RoamNode) => extractTodoistIdFromNodeLike(node),
+    options: {
+      preserveWhen: (node: RoamNode) => shouldPreserveBlock(node),
+    },
+  }, roamApi).withChildrenReconciler({
+    extractKey: extractPropertyKey,
+    isSpecialBlock: isCommentWrapper,
+  });
+}
+
+/**
+ * Determines if a block should be preserved during cleanup.
+ * Preserves completed tasks even when they're no longer in the source.
+ */
+function shouldPreserveBlock(node: RoamNode): boolean {
+  const content = node.text ?? "";
+  const status = extractTodoistStatus(content);
+
+  if (status === "completed") {
+    return true;
+  }
+
+  // Check children for todoist-status or todoist-completed properties
+  for (const child of node.children ?? []) {
+    const childStatus = extractTodoistStatus(child.text ?? "");
+    if (childStatus === "completed") {
+      return true;
+    }
+    if (hasCompletedProperty(child.text ?? "")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 async function writeBlocksToPage(pageName: string, blocks: BlockPayload[]) {
   // ensurePage/createPage includes its own delay when creating new pages
   const pageUid = await ensurePage(pageName);
 
-  const existingTree = getBasicTreeByParentUid(pageUid);
-  const blockMap = buildBlockMap(existingTree);
-
-  // Log existing blocks for debugging
-  const existingIds = Array.from(blockMap.keys());
-  const existingTexts = existingTree.map(n => ({
-    text: n.text?.substring(0, 50) + "...",
-    childCount: n.children?.length ?? 0,
-    firstChildText: n.children?.[0]?.text?.substring(0, 50) ?? "no children"
-  }));
-
-  logDebug("write_blocks_to_page", {
+  logDebug("write_blocks_to_page_start", {
     pageName,
     pageUid,
-    existingBlocksCount: existingTree.length,
-    blockMapSize: blockMap.size,
-    existingIds,
-    existingTexts,
     newBlocksCount: blocks.length,
   });
 
-  const seenIds = new Set<string>();
-  let blockCount = 0;
-  for (const block of blocks) {
-    // Extract todoist-id from child blocks (new structure) or main text (legacy)
-    const todoistId = extractTodoistIdFromBlock(block);
-    if (!todoistId) {
-      continue;
-    }
-    seenIds.add(todoistId);
+  // Use reconciler for efficient incremental sync
+  const reconciler = createTodoistReconciler();
+  const stats = await reconciler.reconcile(pageUid, blocks);
 
-    const existing = blockMap.get(todoistId);
-    if (existing) {
-      // Update main block text if changed
-      if (existing.text !== block.text) {
-        logDebug("update_existing_block", { todoistId, uid: existing.uid });
-        await updateBlock({ uid: existing.uid, text: block.text });
-        await delay(MUTATION_DELAY_MS);
-      }
-      // Sync children (properties + comments)
-      await syncChildren(existing.uid, block.children);
-    } else {
-      logDebug("create_new_block", { todoistId, pageName });
-      // createBlock includes its own delays for rate limiting
-      await createBlock({
-        parentUid: pageUid,
-        order: "last",
-        node: toInputNode(block),
-      });
-    }
+  logDebug("write_blocks_to_page_complete", {
+    pageName,
+    ...stats,
+  });
 
-    blockCount++;
-    await maybeYield(blockCount);
-  }
-
-  await removeObsoleteBlocks(blockMap, seenIds);
   await updatePlaceholderState(pageUid);
 }
 
@@ -306,94 +314,12 @@ async function ensurePage(pageName: string): Promise<string> {
   return uid;
 }
 
-async function removeObsoleteBlocks(blockMap: Map<string, RoamBasicNode>, seenIds: Set<string>) {
-  let removeCount = 0;
-  for (const [todoistId, node] of blockMap.entries()) {
-    if (seenIds.has(todoistId)) {
-      continue;
-    }
-    const content = node.text ?? "";
-    const status = extractTodoistStatus(content);
-    if (status === "completed") {
-      continue;
-    }
-    if (!status && hasCompletedProperty(content)) {
-      continue;
-    }
-    await deleteBlock(node.uid);
-    await delay(MUTATION_DELAY_MS);
-
-    removeCount++;
-    await maybeYield(removeCount);
-  }
-}
-
 /**
  * Extracts todoist-id from a BlockPayload.
  * Delegates to the unified extractTodoistIdFromNodeLike helper.
  */
 function extractTodoistIdFromBlock(block: BlockPayload): string | undefined {
   return extractTodoistIdFromNodeLike(block);
-}
-
-/**
- * Synchronizes child blocks (properties and comments) for an existing task block.
- * Updates existing properties, creates new ones, and handles comment wrappers.
- */
-async function syncChildren(parentUid: string, newChildren: BlockPayload[]) {
-  const existingChildren = getBasicTreeByParentUid(parentUid);
-
-  // Build a map of existing property blocks by their property key (e.g., "todoist-id")
-  const existingPropsMap = new Map<string, RoamBasicNode>();
-  for (const child of existingChildren) {
-    const propKey = extractPropertyKey(child.text);
-    if (propKey) {
-      existingPropsMap.set(propKey, child);
-    }
-  }
-
-  // Process new children
-  let childCount = 0;
-  for (const newChild of newChildren) {
-    const propKey = extractPropertyKey(newChild.text);
-
-    if (propKey) {
-      // It's a property block
-      const existing = existingPropsMap.get(propKey);
-      if (existing) {
-        // Update if changed
-        if (existing.text !== newChild.text) {
-          await updateBlock({ uid: existing.uid, text: newChild.text });
-          await delay(MUTATION_DELAY_MS);
-        }
-        existingPropsMap.delete(propKey); // Mark as processed
-      } else {
-        // Create new property - createBlock includes its own delays
-        await createBlock({
-          parentUid,
-          order: "last",
-          node: toInputNode(newChild),
-        });
-      }
-    } else if (isCommentWrapper(newChild.text)) {
-      // It's a comment wrapper - delete old one and recreate
-      for (const child of existingChildren) {
-        if (isCommentWrapper(child.text)) {
-          await deleteBlock(child.uid);
-          await delay(MUTATION_DELAY_MS);
-        }
-      }
-      // createBlock includes its own delays
-      await createBlock({
-        parentUid,
-        order: "last",
-        node: toInputNode(newChild),
-      });
-    }
-
-    childCount++;
-    await maybeYield(childCount);
-  }
 }
 
 /**
@@ -756,12 +682,5 @@ function resolveStatusAlias(status: string, statusAliases: StatusAliases): strin
     default:
       return status;
   }
-}
-
-function toInputNode(payload: BlockPayload): InputTextNode {
-  return {
-    text: payload.text,
-    children: payload.children.map(toInputNode),
-  };
 }
 

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -244,7 +244,15 @@ function createTodoistReconciler() {
   const roamApi = createRoamApiAdapter();
 
   return new BlockReconciler<BlockPayload>({
-    extractId: (block) => extractTodoistIdFromBlock(block) ?? "",
+    extractId: (block) => {
+      const id = extractTodoistIdFromBlock(block);
+      if (!id) {
+        // This should not happen as we filter blocks without IDs before reconciling.
+        // If it does, throw to prevent silent data corruption.
+        throw new Error(`Block missing Todoist ID: ${block.text.substring(0, 50)}`);
+      }
+      return id;
+    },
     buildBlock: (block) => block as ReconcilerBlockPayload,
     extractIdFromBlock: (node: RoamNode) => extractTodoistIdFromNodeLike(node),
     options: {
@@ -259,12 +267,18 @@ function createTodoistReconciler() {
 /**
  * Determines if a block should be preserved during cleanup.
  * Preserves completed tasks even when they're no longer in the source.
+ * Handles both new structure (properties in children) and legacy (properties in main text).
  */
 function shouldPreserveBlock(node: RoamNode): boolean {
   const content = node.text ?? "";
   const status = extractTodoistStatus(content);
 
   if (status === "completed") {
+    return true;
+  }
+
+  // Legacy: check main block text for todoist-completed property
+  if (hasCompletedProperty(content)) {
     return true;
   }
 
@@ -286,15 +300,29 @@ async function writeBlocksToPage(pageName: string, blocks: BlockPayload[]) {
   // ensurePage/createPage includes its own delay when creating new pages
   const pageUid = await ensurePage(pageName);
 
+  // Filter out blocks without a valid Todoist ID to prevent collisions
+  const validBlocks = blocks.filter((block) => {
+    const id = extractTodoistIdFromBlock(block);
+    if (!id) {
+      logDebug("write_blocks_skip_no_id", {
+        text: block.text.substring(0, 50),
+      });
+      return false;
+    }
+    return true;
+  });
+
   logDebug("write_blocks_to_page_start", {
     pageName,
     pageUid,
-    newBlocksCount: blocks.length,
+    totalBlocks: blocks.length,
+    validBlocks: validBlocks.length,
+    skippedNoId: blocks.length - validBlocks.length,
   });
 
   // Use reconciler for efficient incremental sync
   const reconciler = createTodoistReconciler();
-  const stats = await reconciler.reconcile(pageUid, blocks);
+  const stats = await reconciler.reconcile(pageUid, validBlocks);
 
   logDebug("write_blocks_to_page_complete", {
     pageName,

--- a/src/reconciler/block-reconciler.ts
+++ b/src/reconciler/block-reconciler.ts
@@ -1,0 +1,249 @@
+import type {
+  BlockPayload,
+  RoamNode,
+  ReconcilerConfig,
+  SyncStats,
+} from "./types";
+import type { RoamApiAdapter } from "./roam-api-adapter";
+import { delay, maybeYield, MUTATION_DELAY_MS, YIELD_BATCH_SIZE } from "../settings";
+import { logDebug } from "../logger";
+import { ChildrenReconciler, type ChildReconcilerConfig } from "./children-reconciler";
+
+/**
+ * Reconciles a list of source items with existing Roam blocks.
+ * Only creates, updates, or deletes blocks when necessary.
+ */
+export class BlockReconciler<T> {
+  private readonly mutationDelayMs: number;
+  private readonly yieldBatchSize: number;
+  private childrenReconciler: ChildrenReconciler | null = null;
+
+  constructor(
+    private readonly config: ReconcilerConfig<T>,
+    private readonly roamApi: RoamApiAdapter
+  ) {
+    this.mutationDelayMs = config.options?.mutationDelayMs ?? MUTATION_DELAY_MS;
+    this.yieldBatchSize = config.options?.yieldBatchSize ?? YIELD_BATCH_SIZE;
+  }
+
+  /**
+   * Sets up the children reconciler for syncing child blocks (properties).
+   */
+  withChildrenReconciler(config: ChildReconcilerConfig): this {
+    this.childrenReconciler = new ChildrenReconciler(config, this.roamApi);
+    return this;
+  }
+
+  /**
+   * Reconciles items with existing blocks under a parent.
+   *
+   * @param parentUid UID of the parent block or page.
+   * @param items Source items to reconcile.
+   * @returns Statistics about the sync operation.
+   */
+  async reconcile(parentUid: string, items: T[]): Promise<SyncStats> {
+    const stats: SyncStats = {
+      total: items.length,
+      skipped: 0,
+      created: 0,
+      updated: 0,
+      deleted: 0,
+    };
+
+    // Get existing blocks
+    const existingNodes = this.roamApi.getChildren(parentUid);
+    const existingMap = this.buildExistingMap(existingNodes);
+
+    logDebug("reconciler_start", {
+      parentUid,
+      itemCount: items.length,
+      existingBlockCount: existingNodes.length,
+      mappedBlockCount: existingMap.size,
+    });
+
+    // Track which IDs we've seen
+    const seenIds = new Set<string>();
+    let operationCount = 0;
+
+    // Process each item
+    for (const item of items) {
+      const id = this.config.extractId(item);
+      seenIds.add(id);
+
+      const newBlock = this.config.buildBlock(item);
+      const existingNode = existingMap.get(id);
+
+      if (existingNode) {
+        // Block exists - check if it changed
+        const unchanged = this.isUnchanged(existingNode, newBlock);
+
+        if (unchanged) {
+          stats.skipped++;
+          logDebug("reconciler_skip", { id, reason: "unchanged" });
+        } else {
+          await this.updateExistingBlock(existingNode, newBlock);
+          stats.updated++;
+          logDebug("reconciler_update", { id, uid: existingNode.uid });
+        }
+      } else {
+        // Block doesn't exist - create it
+        await this.createNewBlock(parentUid, newBlock);
+        stats.created++;
+        logDebug("reconciler_create", { id });
+      }
+
+      operationCount++;
+      await maybeYield(operationCount);
+      this.config.options?.onProgress?.(stats);
+    }
+
+    // Remove obsolete blocks
+    stats.deleted = await this.removeObsolete(existingMap, seenIds);
+
+    logDebug("reconciler_complete", { ...stats });
+    return stats;
+  }
+
+  /**
+   * Builds a map of existing blocks by their extracted ID.
+   */
+  private buildExistingMap(nodes: RoamNode[]): Map<string, RoamNode> {
+    const map = new Map<string, RoamNode>();
+
+    for (const node of nodes) {
+      const id = this.config.extractIdFromBlock(node);
+      if (id) {
+        map.set(id, node);
+        logDebug("reconciler_map_entry", { id, uid: node.uid });
+      }
+    }
+
+    return map;
+  }
+
+  /**
+   * Compares an existing block with a new block payload.
+   * Returns true if they are equivalent (no update needed).
+   */
+  private isUnchanged(existing: RoamNode, newBlock: BlockPayload): boolean {
+    // Compare main text
+    if (existing.text !== newBlock.text) {
+      return false;
+    }
+
+    // Compare children count
+    const existingChildren = existing.children ?? [];
+    const newChildren = newBlock.children ?? [];
+
+    if (existingChildren.length !== newChildren.length) {
+      return false;
+    }
+
+    // Recursively compare children
+    for (let i = 0; i < existingChildren.length; i++) {
+      const existingChild = existingChildren[i];
+      const newChild = newChildren[i];
+
+      if (!this.isChildUnchanged(existingChild, newChild)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Compares a single child node with a new child payload.
+   */
+  private isChildUnchanged(existing: RoamNode, newChild: BlockPayload): boolean {
+    if (existing.text !== newChild.text) {
+      return false;
+    }
+
+    const existingChildren = existing.children ?? [];
+    const newChildren = newChild.children ?? [];
+
+    if (existingChildren.length !== newChildren.length) {
+      return false;
+    }
+
+    for (let i = 0; i < existingChildren.length; i++) {
+      if (!this.isChildUnchanged(existingChildren[i], newChildren[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Updates an existing block and its children.
+   */
+  private async updateExistingBlock(
+    existing: RoamNode,
+    newBlock: BlockPayload
+  ): Promise<void> {
+    // Update main text if changed
+    if (existing.text !== newBlock.text) {
+      await this.roamApi.updateBlock(existing.uid, newBlock.text);
+      await delay(this.mutationDelayMs);
+    }
+
+    // Sync children if reconciler is configured
+    if (this.childrenReconciler && newBlock.children) {
+      await this.childrenReconciler.syncChildren(
+        existing.uid,
+        existing.children ?? [],
+        newBlock.children
+      );
+    }
+  }
+
+  /**
+   * Creates a new block with its children.
+   */
+  private async createNewBlock(
+    parentUid: string,
+    block: BlockPayload
+  ): Promise<void> {
+    // createBlock in roam-api-adapter already handles children recursively
+    await this.roamApi.createBlock(parentUid, block, "last");
+  }
+
+  /**
+   * Removes blocks that are no longer in the source list.
+   * Respects the preserveWhen option.
+   */
+  private async removeObsolete(
+    existingMap: Map<string, RoamNode>,
+    seenIds: Set<string>
+  ): Promise<number> {
+    let deletedCount = 0;
+    let operationCount = 0;
+
+    for (const [id, node] of existingMap.entries()) {
+      // Skip if we processed this ID
+      if (seenIds.has(id)) {
+        continue;
+      }
+
+      // Check if block should be preserved
+      if (this.config.options?.preserveWhen?.(node)) {
+        logDebug("reconciler_preserve", { id, uid: node.uid });
+        continue;
+      }
+
+      // Delete the block
+      await this.roamApi.deleteBlock(node.uid);
+      await delay(this.mutationDelayMs);
+      deletedCount++;
+
+      logDebug("reconciler_delete", { id, uid: node.uid });
+
+      operationCount++;
+      await maybeYield(operationCount);
+    }
+
+    return deletedCount;
+  }
+}

--- a/src/reconciler/block-reconciler.ts
+++ b/src/reconciler/block-reconciler.ts
@@ -3,11 +3,12 @@ import type {
   RoamNode,
   ReconcilerConfig,
   SyncStats,
+  ChildReconcilerConfig,
 } from "./types";
 import type { RoamApiAdapter } from "./roam-api-adapter";
-import { delay, maybeYield, MUTATION_DELAY_MS, YIELD_BATCH_SIZE } from "../settings";
+import { delay, yieldToMain, MUTATION_DELAY_MS, YIELD_BATCH_SIZE } from "../settings";
 import { logDebug } from "../logger";
-import { ChildrenReconciler, type ChildReconcilerConfig } from "./children-reconciler";
+import { ChildrenReconciler } from "./children-reconciler";
 
 /**
  * Reconciles a list of source items with existing Roam blocks.
@@ -93,7 +94,7 @@ export class BlockReconciler<T> {
       }
 
       operationCount++;
-      await maybeYield(operationCount);
+      await this.maybeYieldToMain(operationCount);
       this.config.options?.onProgress?.(stats);
     }
 
@@ -241,9 +242,18 @@ export class BlockReconciler<T> {
       logDebug("reconciler_delete", { id, uid: node.uid });
 
       operationCount++;
-      await maybeYield(operationCount);
+      await this.maybeYieldToMain(operationCount);
     }
 
     return deletedCount;
+  }
+
+  /**
+   * Yields to the main thread periodically based on the configured batch size.
+   */
+  private async maybeYieldToMain(count: number): Promise<void> {
+    if (count % this.yieldBatchSize === 0) {
+      await yieldToMain();
+    }
   }
 }

--- a/src/reconciler/children-reconciler.ts
+++ b/src/reconciler/children-reconciler.ts
@@ -1,31 +1,7 @@
-import type { BlockPayload, RoamNode } from "./types";
+import type { BlockPayload, RoamNode, ChildReconcilerConfig } from "./types";
 import type { RoamApiAdapter } from "./roam-api-adapter";
 import { delay, maybeYield, MUTATION_DELAY_MS } from "../settings";
 import { logDebug } from "../logger";
-
-/**
- * Configuration for reconciling child blocks (properties).
- */
-export interface ChildReconcilerConfig {
-  /**
-   * Extracts the property key from block text.
-   * For example, extracts "todoist-id" from "todoist-id:: value".
-   * Returns undefined if the text is not a property block.
-   */
-  extractKey: (text: string) => string | undefined;
-
-  /**
-   * Identifies special blocks that need different handling.
-   * For example, comment wrapper blocks that should be replaced entirely.
-   */
-  isSpecialBlock?: (text: string) => boolean;
-
-  /**
-   * Delay in milliseconds between mutations.
-   * Default: 100ms
-   */
-  mutationDelayMs?: number;
-}
 
 /**
  * Statistics about a children sync operation.
@@ -116,6 +92,7 @@ export class ChildrenReconciler {
         } else {
           // Create new property
           await this.roamApi.createBlock(parentUid, newChild, "last");
+          await delay(this.mutationDelayMs);
           stats.created++;
           logDebug("children_reconciler_create", { key });
         }
@@ -132,9 +109,21 @@ export class ChildrenReconciler {
 
         // Create the new special block
         await this.roamApi.createBlock(parentUid, newChild, "last");
+        await delay(this.mutationDelayMs);
         stats.created++;
         logDebug("children_reconciler_create_special", { text: newChild.text.substring(0, 30) });
       }
+
+      operationCount++;
+      await maybeYield(operationCount);
+    }
+
+    // Delete orphaned property blocks that are no longer in the desired state
+    for (const [key, orphanBlock] of existingPropsMap) {
+      await delay(this.mutationDelayMs);
+      await this.roamApi.deleteBlock(orphanBlock.uid);
+      stats.deleted++;
+      logDebug("children_reconciler_delete_orphan", { key, uid: orphanBlock.uid });
 
       operationCount++;
       await maybeYield(operationCount);

--- a/src/reconciler/children-reconciler.ts
+++ b/src/reconciler/children-reconciler.ts
@@ -1,0 +1,146 @@
+import type { BlockPayload, RoamNode } from "./types";
+import type { RoamApiAdapter } from "./roam-api-adapter";
+import { delay, maybeYield, MUTATION_DELAY_MS } from "../settings";
+import { logDebug } from "../logger";
+
+/**
+ * Configuration for reconciling child blocks (properties).
+ */
+export interface ChildReconcilerConfig {
+  /**
+   * Extracts the property key from block text.
+   * For example, extracts "todoist-id" from "todoist-id:: value".
+   * Returns undefined if the text is not a property block.
+   */
+  extractKey: (text: string) => string | undefined;
+
+  /**
+   * Identifies special blocks that need different handling.
+   * For example, comment wrapper blocks that should be replaced entirely.
+   */
+  isSpecialBlock?: (text: string) => boolean;
+
+  /**
+   * Delay in milliseconds between mutations.
+   * Default: 100ms
+   */
+  mutationDelayMs?: number;
+}
+
+/**
+ * Statistics about a children sync operation.
+ */
+export interface ChildSyncStats {
+  skipped: number;
+  updated: number;
+  created: number;
+  deleted: number;
+}
+
+/**
+ * Reconciles child blocks (properties) of a parent block.
+ * Updates existing properties, creates new ones, and handles special blocks.
+ */
+export class ChildrenReconciler {
+  private readonly mutationDelayMs: number;
+
+  constructor(
+    private readonly config: ChildReconcilerConfig,
+    private readonly roamApi: RoamApiAdapter
+  ) {
+    this.mutationDelayMs = config.mutationDelayMs ?? MUTATION_DELAY_MS;
+  }
+
+  /**
+   * Synchronizes child blocks of a parent.
+   *
+   * @param parentUid UID of the parent block.
+   * @param existingChildren Current child nodes from Roam.
+   * @param newChildren Desired child payloads.
+   * @returns Statistics about the sync.
+   */
+  async syncChildren(
+    parentUid: string,
+    existingChildren: RoamNode[],
+    newChildren: BlockPayload[]
+  ): Promise<ChildSyncStats> {
+    const stats: ChildSyncStats = {
+      skipped: 0,
+      updated: 0,
+      created: 0,
+      deleted: 0,
+    };
+
+    // Build map of existing property blocks by key
+    const existingPropsMap = new Map<string, RoamNode>();
+    const existingSpecialBlocks: RoamNode[] = [];
+
+    for (const child of existingChildren) {
+      const key = this.config.extractKey(child.text);
+      if (key) {
+        existingPropsMap.set(key, child);
+      } else if (this.config.isSpecialBlock?.(child.text)) {
+        existingSpecialBlocks.push(child);
+      }
+    }
+
+    logDebug("children_reconciler_start", {
+      parentUid,
+      existingPropsCount: existingPropsMap.size,
+      existingSpecialCount: existingSpecialBlocks.length,
+      newChildrenCount: newChildren.length,
+    });
+
+    let operationCount = 0;
+
+    // Process new children
+    for (const newChild of newChildren) {
+      const key = this.config.extractKey(newChild.text);
+
+      if (key) {
+        // It's a property block
+        const existing = existingPropsMap.get(key);
+
+        if (existing) {
+          // Update if changed
+          if (existing.text === newChild.text) {
+            stats.skipped++;
+            logDebug("children_reconciler_skip", { key, reason: "unchanged" });
+          } else {
+            await this.roamApi.updateBlock(existing.uid, newChild.text);
+            await delay(this.mutationDelayMs);
+            stats.updated++;
+            logDebug("children_reconciler_update", { key, uid: existing.uid });
+          }
+          existingPropsMap.delete(key); // Mark as processed
+        } else {
+          // Create new property
+          await this.roamApi.createBlock(parentUid, newChild, "last");
+          stats.created++;
+          logDebug("children_reconciler_create", { key });
+        }
+      } else if (this.config.isSpecialBlock?.(newChild.text)) {
+        // It's a special block (e.g., comment wrapper)
+        // Delete all existing special blocks and recreate
+        for (const specialBlock of existingSpecialBlocks) {
+          await this.roamApi.deleteBlock(specialBlock.uid);
+          await delay(this.mutationDelayMs);
+          stats.deleted++;
+          logDebug("children_reconciler_delete_special", { uid: specialBlock.uid });
+        }
+        existingSpecialBlocks.length = 0; // Clear to avoid re-deleting
+
+        // Create the new special block
+        await this.roamApi.createBlock(parentUid, newChild, "last");
+        stats.created++;
+        logDebug("children_reconciler_create_special", { text: newChild.text.substring(0, 30) });
+      }
+
+      operationCount++;
+      await maybeYield(operationCount);
+    }
+
+    logDebug("children_reconciler_complete", { ...stats });
+    return stats;
+  }
+}

--- a/src/reconciler/index.ts
+++ b/src/reconciler/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Roam Block Reconciler
+ *
+ * A library for efficiently syncing data from external sources (like Todoist)
+ * to Roam blocks. Only creates, updates, or deletes blocks when necessary.
+ *
+ * @example
+ * ```typescript
+ * import { BlockReconciler, createRoamApiAdapter } from "./reconciler";
+ *
+ * const reconciler = new BlockReconciler<Task>({
+ *   extractId: (task) => String(task.id),
+ *   buildBlock: (task) => ({ text: task.content, children: [] }),
+ *   extractIdFromBlock: (node) => extractIdFromText(node.text),
+ *   options: {
+ *     preserveWhen: (node) => hasCompletedStatus(node),
+ *   }
+ * }, createRoamApiAdapter());
+ *
+ * const stats = await reconciler.reconcile(pageUid, tasks);
+ * console.log(`Skipped: ${stats.skipped}, Updated: ${stats.updated}`);
+ * ```
+ */
+
+// Types
+export type {
+  BlockPayload,
+  RoamNode,
+  ReconcilerConfig,
+  ReconcilerOptions,
+  SyncStats,
+  ChildReconcilerConfig,
+} from "./types";
+
+// Roam API Adapter
+export type { RoamApiAdapter } from "./roam-api-adapter";
+export { createRoamApiAdapter } from "./roam-api-adapter";
+
+// Block Reconciler
+export { BlockReconciler } from "./block-reconciler";
+
+// Children Reconciler
+export { ChildrenReconciler, type ChildSyncStats } from "./children-reconciler";

--- a/src/reconciler/roam-api-adapter.ts
+++ b/src/reconciler/roam-api-adapter.ts
@@ -1,0 +1,94 @@
+import type { BlockPayload, RoamNode } from "./types";
+import {
+  getBasicTreeByParentUid,
+  createBlock as roamCreateBlock,
+  updateBlock as roamUpdateBlock,
+  deleteBlock as roamDeleteBlock,
+  type RoamBasicNode,
+  type InputTextNode,
+} from "../settings";
+
+/**
+ * Adapter interface for Roam API operations.
+ * Abstracts the underlying Roam API to make the reconciler testable.
+ */
+export interface RoamApiAdapter {
+  /**
+   * Gets child blocks of a parent block or page.
+   */
+  getChildren(parentUid: string): RoamNode[];
+
+  /**
+   * Creates a new block under a parent.
+   * @returns The UID of the created block.
+   */
+  createBlock(
+    parentUid: string,
+    block: BlockPayload,
+    order?: number | "last"
+  ): Promise<string>;
+
+  /**
+   * Updates the text of an existing block.
+   */
+  updateBlock(uid: string, text: string): Promise<void>;
+
+  /**
+   * Deletes a block by its UID.
+   */
+  deleteBlock(uid: string): Promise<void>;
+}
+
+/**
+ * Converts a RoamBasicNode to the RoamNode interface used by the reconciler.
+ */
+function toRoamNode(node: RoamBasicNode): RoamNode {
+  return {
+    text: node.text ?? "",
+    uid: node.uid,
+    children: node.children?.map(toRoamNode),
+  };
+}
+
+/**
+ * Converts a BlockPayload to the InputTextNode format expected by Roam API.
+ */
+function toInputNode(payload: BlockPayload): InputTextNode {
+  return {
+    text: payload.text,
+    children: payload.children?.map(toInputNode),
+  };
+}
+
+/**
+ * Creates the default Roam API adapter using roamAlphaAPI.
+ */
+export function createRoamApiAdapter(): RoamApiAdapter {
+  return {
+    getChildren(parentUid: string): RoamNode[] {
+      const nodes = getBasicTreeByParentUid(parentUid);
+      return nodes.map(toRoamNode);
+    },
+
+    async createBlock(
+      parentUid: string,
+      block: BlockPayload,
+      order: number | "last" = "last"
+    ): Promise<string> {
+      const uid = await roamCreateBlock({
+        parentUid,
+        order,
+        node: toInputNode(block),
+      });
+      return uid;
+    },
+
+    async updateBlock(uid: string, text: string): Promise<void> {
+      await roamUpdateBlock({ uid, text });
+    },
+
+    async deleteBlock(uid: string): Promise<void> {
+      await roamDeleteBlock(uid);
+    },
+  };
+}

--- a/src/reconciler/types.ts
+++ b/src/reconciler/types.ts
@@ -1,0 +1,107 @@
+/**
+ * Block payload for creating/updating blocks in Roam.
+ */
+export type BlockPayload = {
+  text: string;
+  children?: BlockPayload[];
+};
+
+/**
+ * Represents a block node in Roam's tree structure.
+ */
+export interface RoamNode {
+  text: string;
+  uid: string;
+  children?: RoamNode[];
+}
+
+/**
+ * Configuration for reconciling items with Roam blocks.
+ * @template T The type of source items (e.g., TodoistBackupTask).
+ */
+export interface ReconcilerConfig<T> {
+  /**
+   * Extracts a unique identifier from the source item.
+   * This ID is used to match items with existing blocks.
+   */
+  extractId: (item: T) => string;
+
+  /**
+   * Builds a block payload from the source item.
+   */
+  buildBlock: (item: T) => BlockPayload;
+
+  /**
+   * Extracts the unique identifier from an existing Roam block.
+   * Returns undefined if the block doesn't have a recognizable ID.
+   */
+  extractIdFromBlock: (node: RoamNode) => string | undefined;
+
+  /**
+   * Optional configuration options.
+   */
+  options?: ReconcilerOptions;
+}
+
+/**
+ * Options for customizing reconciliation behavior.
+ */
+export interface ReconcilerOptions {
+  /**
+   * Determines whether a block should be preserved even when
+   * its corresponding item was removed from the source.
+   * Useful for keeping completed tasks that are no longer in the active list.
+   */
+  preserveWhen?: (node: RoamNode) => boolean;
+
+  /**
+   * Callback invoked during sync to report progress.
+   */
+  onProgress?: (stats: SyncStats) => void;
+
+  /**
+   * Delay in milliseconds between Roam API mutations.
+   * Default: 100ms
+   */
+  mutationDelayMs?: number;
+
+  /**
+   * Number of operations to process before yielding to the main thread.
+   * Default: 3
+   */
+  yieldBatchSize?: number;
+}
+
+/**
+ * Statistics about a sync operation.
+ */
+export interface SyncStats {
+  /** Total number of items processed */
+  total: number;
+  /** Blocks that were unchanged and skipped */
+  skipped: number;
+  /** New blocks created */
+  created: number;
+  /** Existing blocks that were updated */
+  updated: number;
+  /** Obsolete blocks that were deleted */
+  deleted: number;
+}
+
+/**
+ * Configuration for reconciling child blocks (properties).
+ */
+export interface ChildReconcilerConfig {
+  /**
+   * Extracts the property key from block text.
+   * For example, extracts "todoist-id" from "todoist-id:: value".
+   * Returns undefined if the text is not a property block.
+   */
+  extractKey: (text: string) => string | undefined;
+
+  /**
+   * Identifies special blocks that need different handling.
+   * For example, comment wrapper blocks.
+   */
+  isSpecialBlock?: (text: string) => boolean;
+}

--- a/src/reconciler/types.ts
+++ b/src/reconciler/types.ts
@@ -101,7 +101,13 @@ export interface ChildReconcilerConfig {
 
   /**
    * Identifies special blocks that need different handling.
-   * For example, comment wrapper blocks.
+   * For example, comment wrapper blocks that should be replaced entirely.
    */
   isSpecialBlock?: (text: string) => boolean;
+
+  /**
+   * Delay in milliseconds between Roam API mutations.
+   * Default: 100ms
+   */
+  mutationDelayMs?: number;
 }


### PR DESCRIPTION
Every sync was rewriting all blocks even when nothing changed. This caused unnecessary API calls and potential flickering in the UI.

Introduced a reconciler module that compares existing blocks with new data and only performs mutations when there's an actual difference. It tracks skipped/created/updated/deleted counts for visibility into what each sync actually does.